### PR TITLE
Quick Fix

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,13 +1,8 @@
 FROM python:3.11
 
-RUN pip install --upgrade pip
-RUN apt-get update
-RUN apt-get install python3-pip -y
 RUN pip install flask
 RUN pip install flask-cors
 RUN pip install redis
-RUN pip install flake8
-
 
 COPY . .
 

--- a/cmd/zsh_build_and_mount_all.sh
+++ b/cmd/zsh_build_and_mount_all.sh
@@ -1,0 +1,14 @@
+docker stop piouteur-redis
+docker stop piouteur-api
+docker stop piouteur-front
+docker rm piouteur-redis
+docker rm piouteur-api
+docker rm piouteur-front
+docker run --name piouteur-redis -p 6379:6379 -d redis
+cd ./backend
+docker build -t piouteur-api .
+docker run --name piouteur-api -p 5001:5001 -d piouteur-api
+cd ../frontend
+docker build -t piouteur-front .
+docker run --name piouteur-front -p 80:80 -d piouteur-front
+cd ..

--- a/cmd/zsh_rm_all.sh
+++ b/cmd/zsh_rm_all.sh
@@ -1,0 +1,6 @@
+docker stop piouteur-redis
+docker stop piouteur-api
+docker stop piouteur-front
+docker rm piouteur-redis
+docker rm piouteur-api
+docker rm piouteur-front


### PR DESCRIPTION
Pas besoin de `apt install/update`,   l'image `python:3.11` contient déjà `pip`, ni de `flake8`
( ça a bloqué lors du build de l'image, d'ailleurs je me demande pourquoi tu voulais utiliser `flake8` ? 🤔 )

---

En dehors de ce détail : 
### Félicitation à toi ! 👏 C'est de l'excellent travail !  🚀  